### PR TITLE
File copying fix

### DIFF
--- a/src/tritongrader/autograder.py
+++ b/src/tritongrader/autograder.py
@@ -77,9 +77,9 @@ class Autograder:
         # path to solution directory as specified in docstring
         self.tests_path = tests_path
         # path to the in/ directory containing cmdX and testX files.
-        self.tests_in_path = f"{self.tests_path}/in"
+        self.tests_in_path = os.path.join(self.tests_path, "in")
         # path to the exp/ directory containing errX and outX files.
-        self.tests_exp_path = f"{self.tests_path}/exp"
+        self.tests_exp_path = os.path.join(self.tests_path, "exp") 
         # path to the directory containing student submission files.
         self.submission_path = submission_path
         # A sandbox directory where submission and test files will be copied to.
@@ -103,10 +103,10 @@ class Autograder:
     ):
         for test_id, point_value in test_list:
             test_case = IOTestCase(
-                command_path=f"{self.tests_in_path}/cmd{test_id}",
-                input_path=f"{self.tests_in_path}/test{test_id}",
-                exp_stdout_path=f"{self.tests_exp_path}/out{test_id}",
-                exp_stderr_path=f"{self.tests_exp_path}/err{test_id}",
+                command_path=os.path.join(self.tests_in_path, f"cmd{test_id}"),
+                input_path=os.path.join(self.tests_in_path, f"test{test_id}"),
+                exp_stdout_path=os.path.join(self.tests_exp_path, f"out{test_id}"),
+                exp_stderr_path=os.path.join(self.tests_exp_path, f"err{test_id}"),
                 name=str(test_id) if not prefix else f"{prefix} - {test_id}",
                 timeout=default_timeout_ms / 1000,
                 arm=self.arm,
@@ -170,24 +170,21 @@ class Autograder:
             else self.get_default_build_command()
         )
     
+    def copy2sandbox(self, src_dir, item):
+        path = os.path.realpath(os.path.join(src_dir, item))
+        dst = os.path.join(self.sandbox.name, item)
+        if os.path.isfile(path):
+            shutil.copy2(path, dst)
+        elif os.path.isdir(path):
+            shutil.copytree(path, dst)
+    
     def copy_submission_files(self):
         for f in self.required_files:
-            logger.info(f"Copying {f} to sandbox directory...")
-            shutil.copyfile(f"{self.submission_path}/{f}", f"{self.sandbox.name}/{f}")
+            self.copy2sandbox(self.submission_path, f)
 
     def copy_supplied_files(self):
         for f in self.supplied_files:
-            # create directories if supplied files are paths (e.g. "in/BOOK")
-            tokens = f.rsplit("/", 1)
-            if len(tokens) == 2:
-                parent_dir = self.sandbox.name + "/" + tokens[0]
-                filename = tokens[1]
-                run(f"mkdir -p {parent_dir}")
-            else:
-                parent_dir = self.sandbox.name
-                filename = tokens[0]
-            shutil.copyfile(f"{self.tests_path}/{f}", f"{parent_dir}/{filename}")
-            run(f"cp {self.tests_path}/{f} {parent_dir}/{filename}")
+            self.copy2sandbox(self.tests_path, f)
 
     def compile_student_code(self) -> int:
         if self.compiled:

--- a/src/tritongrader/autograder.py
+++ b/src/tritongrader/autograder.py
@@ -194,7 +194,7 @@ class Autograder:
         self.copy_supplied_files()
         os.chdir(self.sandbox.name)
         build_cmd = self.get_build_command()
-        logger.debug(f"{build_cmd=}")
+        logger.debug(f"build_cmd: {build_cmd}")
         compiler_process = run(build_cmd, capture_output=True, text=True)
         compiled = compiler_process.returncode == 0
         if compiled:

--- a/src/tritongrader/test_case.py
+++ b/src/tritongrader/test_case.py
@@ -96,8 +96,8 @@ class IOTestCase(TestCaseBase):
 
     def __str__(self):
         return (
-            f"{self.name} {self.arm=} {self.command_path=} {self.command=} "
-            + f"{self.input_path=} {self.exp_stdout_path=} {self.exp_stderr_path}"
+            f"{self.name} arm={self.arm} cmd_path={self.command_path} cmd={self.command} "
+            + f"input_path={self.input_path} exp_stdout_path={self.exp_stdout_path} exp_stderr_path={self.exp_stderr_path}"
         )
 
     def open_mode(self):

--- a/src/tritongrader/utils.py
+++ b/src/tritongrader/utils.py
@@ -24,8 +24,9 @@ def run(
     sp = subprocess.run(
         command,
         shell=True,
-        capture_output=capture_output or print_output,
-        text=text or print_output,
+        stdout=subprocess.PIPE if capture_output or print_output else None,
+        stderr=subprocess.PIPE if capture_output or print_output else None,
+        universal_newlines=text or print_output,
         timeout=timeout,
     )
     if print_command:


### PR DESCRIPTION
Fixes #7 

### Changes
- More Pythonic way of copying files (using more library functions rather than directly running shell commands),
- More careful file copying (only copy required files as specified. No extra files are copied.)
- Some backward compatibility changes with earlier Python 3 versions.